### PR TITLE
(bug): fix "fatal: not in a git directory" error

### DIFF
--- a/.github/workflows/sync_scaffold.yml
+++ b/.github/workflows/sync_scaffold.yml
@@ -15,18 +15,10 @@ jobs:
     steps:
     - name: Checkout current repo
       uses: actions/checkout@v3
-      with:
-        path: pingcap-docsite-preview
-
-    - name: Checkout docs-staging repo
-      uses: actions/checkout@v3
-      with:
-        repository: 'pingcap/docs-staging'
-        path: docs-staging
 
     - name: Run sync_scaffold script
       run: |
-        git config user.name "PingCAP Docsite Preview Bot"
+        git config user.name "Docsite Preview Bot"
         git config user.email ""
         ./sync_scaffold.sh
         git push


### PR DESCRIPTION
- Fix the "fatal: not in a git directory" error that occurs when executing `git config user.name` in step 4 of `sync_scaffold.yml`. The inconsistency between `path: pingcap-docsite-preview` used for repository checkout and the working directory of step 4 is the root cause.

- Eliminate the redundant `Checkout docs-staging repo` step. This step is already addressed in the `./sync_scaffold.sh` script.

- Update the Git username to `Docsite Preview Bot` for clarity and consistency.
