### PR TITLE
(bug): fix "git add ." command error

### DIFF
--- a/sync_scaffold.sh
+++ b/sync_scaffold.sh
@@ -47,5 +47,5 @@ cp "$CLONE_DIR/$SYNC_JSON_FILE" "./$SYNC_JSON_FILE"
 
 ## Commit changes with the commit SHA from the cloned repository
 CURRENT_SHA=$(git -C "$CLONE_DIR" rev-parse HEAD)
-git add .
+git add . || true
 git commit -m "Sync the scaffold from $REPO_URL/commit/$CURRENT_SHA" || echo "No changes detected"


### PR DESCRIPTION
Fix the issue that `git add .` command exits with "The following paths are ignored by one of your .gitignore files" error message. (the current test dir `actual` is ignored)

This PR replaces the original `git add .` command with `git add . || true`. This modification allows the command to continue execution even if there are ignored files, effectively ignoring the error and preventing the command from terminating prematurely.

