### PR TITLE
feat: exclude empty directories when executing sync_scaffold.sh

### DIFF
--- a/sync_scaffold.sh
+++ b/sync_scaffold.sh
@@ -40,7 +40,7 @@ for file in "${SYNC_FILES[@]}"; do
 done
 
 # Synchronize SRC and DEST
-rsync -av --checksum "${INCLUDES[@]}" --exclude='*' "$SRC" "$DEST"
+rsync -avm --checksum "${INCLUDES[@]}" --exclude='*' "$SRC" "$DEST"
 
 # Copy SYNC_JSON_FILE from CLONE_DIR to the current directory
 cp "$CLONE_DIR/$SYNC_JSON_FILE" "./$SYNC_JSON_FILE"


### PR DESCRIPTION
Signed-off-by: Aolin <aolinz@outlook.com>

Close #8 

To avoid creating empty directories when executing sync_scaffold.sh, this PR introduces `rsync -m` (`--prune-empty-dirs`) option to prune empty directories.

Before:

```
bash sync_scaffold.sh
tree markdown-pages/en/tidb/master/ -L 1

markdown-pages/en/tidb/master/
├── TOC.md
├── _docHome.md
├── _index.md
├── benchmark
├── best-practices
├── br
├── clinic
├── dashboard
├── develop
├── dm
├── faq
├── functions-and-operators
├── information-schema
├── releases
├── sql-statements
├── storage-engine
├── sync-diff-inspector
├── ticdc
├── tidb-binlog
├── tidb-lightning
├── tiflash
└── tiup

20 directories, 3 files
```

After:

```
bash sync_scaffold.sh
tree markdown-pages/en/tidb/master/ -L 1

markdown-pages/en/tidb/master/
├── TOC.md
├── _docHome.md
└── _index.md

1 directory, 3 files
```