### PR TITLE
feat: route preview sync for i18n base branches

### DIFF
--- a/sync_pr.sh
+++ b/sync_pr.sh
@@ -11,6 +11,11 @@
 # preview/pingcap/docs-cn/1234: sync pingcap/docs-cn/pull/1234 to markdown-pages/zh/tidb/{PR_BASE_BRANCH}
 # preview-cloud/pingcap/docs/1234: sync pingcap/docs/pull/1234 to markdown-pages/en/tidbcloud/{PR_BASE_BRANCH}
 # preview-operator/pingcap/docs-tidb-operator/1234: sync pingcap/docs-tidb-operator/pull/1234 to markdown-pages/en/tidb-in-kubernetes/{PR_BASE_BRANCH} and markdown-pages/zh/tidb-in-kubernetes/{PR_BASE_BRANCH}
+#
+# When the PR base branch is an i18n branch of the form i18n-{locale}-{master|release-*},
+# the destination is normalized to markdown-pages/{locale}/{product}/{master|release-*}.
+# Example:
+# preview/pingcap/docs/1234 with base i18n-ja-release-8.5: sync to markdown-pages/ja/tidb/release-8.5
 
 # Prerequisites:
 # 1. Install jq
@@ -44,18 +49,28 @@ get_pr_base_branch() {
 
 }
 
+parse_i18n_base() {
+  TARGET_BRANCH="$BASE_BRANCH"
+  TARGET_LOCALE=""
+
+  if [[ "$BASE_BRANCH" =~ ^i18n-(.+)-(master|release-.+)$ ]]; then
+    TARGET_LOCALE="${BASH_REMATCH[1]}"
+    TARGET_BRANCH="${BASH_REMATCH[2]}"
+  fi
+}
+
 get_destination_suffix() {
   # Determine the product name based on PREVIEW_PRODUCT.
   case "$PREVIEW_PRODUCT" in
   preview)
-    DIR_SUFFIX="tidb/${BASE_BRANCH}"
+    DIR_SUFFIX="tidb/${TARGET_BRANCH}"
     ;;
   preview-cloud)
     DIR_SUFFIX="tidbcloud/master"
     IS_CLOUD=true
     ;;
   preview-operator)
-    DIR_SUFFIX="tidb-in-kubernetes/${BASE_BRANCH}"
+    DIR_SUFFIX="tidb-in-kubernetes/${TARGET_BRANCH}"
     ;;
   *)
     echo "Error: Branch name must start with preview/, preview-cloud/, or preview-operator/."
@@ -68,12 +83,12 @@ generate_sync_tasks() {
   # Define sync tasks for different repositories.
   case "$REPO_NAME" in
   docs)
-    # Sync all modified or added files from the root dir to markdown-pages/en/.
-    SYNC_TASKS=("./,en/")
+    # Sync all modified or added files from the root dir to markdown-pages/{locale}/.
+    SYNC_TASKS=("./,${TARGET_LOCALE:-en}/")
     ;;
   docs-cn)
-    # sync all modified or added files from the root dir to markdown-pages/zh/.
-    SYNC_TASKS=("./,zh/")
+    # sync all modified or added files from the root dir to markdown-pages/{locale}/.
+    SYNC_TASKS=("./,${TARGET_LOCALE:-zh}/")
     ;;
   docs-tidb-operator)
     # Task 1: sync all modified or added files from en/ to markdown-pages/en/.
@@ -114,7 +129,7 @@ perform_sync_task() {
   generate_sync_tasks
 
   # Set the target branch and folders of TOC namespace per product.
-  # These folders are served from a fixed target branch; when BASE_BRANCH differs, they must also be synced there for the preview to reflect changes at their canonical URLs.
+  # These folders are served from a fixed target branch; when TARGET_BRANCH differs, they must also be synced there for the preview to reflect changes at their canonical URLs.
   #  - tidb:               docs.tidb.stable from docs.json (e.g. release-8.5)
   #  - tidb-in-kubernetes: main
   #  - tidbcloud:          master (already the default target, no extra sync needed)
@@ -167,8 +182,8 @@ perform_sync_task() {
 
     commit_changes "Post-process docs (variables replaced, copyable removed)"
 
-    # Sync TOC namespace folders to the target branch path when BASE_BRANCH differs.
-    if [[ -n "$TOC_TARGET_BRANCH" && "$BASE_BRANCH" != "$TOC_TARGET_BRANCH" ]]; then
+    # Sync TOC namespace folders to the target branch path when TARGET_BRANCH differs.
+    if [[ -n "$TOC_TARGET_BRANCH" && "$TARGET_BRANCH" != "$TOC_TARGET_BRANCH" ]]; then
       TOC_TARGET_DIR="$(dirname "$DEST_DIR")/$TOC_TARGET_BRANCH"
 
       if [[ "$TOC_TARGET_DIR" == "$DEST_DIR" ]]; then
@@ -203,7 +218,7 @@ perform_sync_task() {
             ./scripts/replace_variables.py "$TOC_TARGET_DIR" "$TOC_TARGET_DIR/variables.json"
           fi
           (cd "$TOC_TARGET_DIR" && remove_copyable)
-          commit_changes "Sync TOC namespace folders from ${BASE_BRANCH} to ${TOC_TARGET_BRANCH} for preview (task: ${TASK})"
+          commit_changes "Sync TOC namespace folders from ${TARGET_BRANCH} to ${TOC_TARGET_BRANCH} for preview (task: ${TASK})"
         fi
       fi
     fi
@@ -243,6 +258,7 @@ PR_NUMBER=$(echo "$BRANCH_NAME" | cut -d'/' -f4)
 REPO_DIR="temp/$REPO_NAME"
 
 get_pr_base_branch
+parse_i18n_base
 get_destination_suffix
 clone_repo
 perform_sync_task


### PR DESCRIPTION
Parse PR base branches of the form i18n-{locale}-{master|release-*} into TARGET_LOCALE + TARGET_BRANCH, then route the preview destination by the normalized pair. Example: a PR with base i18n-ja-release-8.5 on pingcap/docs lands at markdown-pages/ja/tidb/release-8.5 instead of markdown-pages/en/tidb/i18n-ja-release-8.5.